### PR TITLE
feat: move helper functions to src/utils/helper.js (#2)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 // eslint.config.js
 import js from "@eslint/js";
+import globals from "globals";
 
 export default [
   js.configs.recommended,
@@ -11,6 +12,9 @@ export default [
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",
+      globals: {
+        ...globals.browser,
+      },
     },
     rules: {
       // Aturan custom Anda

--- a/example/index.html
+++ b/example/index.html
@@ -1,1 +1,110 @@
+<!--//C:\OSS\FOSS_Issue\move_helper_function\example\index.html -->
 <!-- TODO: Add example to use validate-form-simple -->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Form Validation Example</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f4f4f4;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            margin: 0;
+        }
+
+        .container {
+            background-color: #fff;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+            width: 400px;
+        }
+
+        h2 {
+            text-align: center;
+            margin-bottom: 20px;
+            color: #333;
+        }
+
+        .form-control {
+            margin-bottom: 15px;
+        }
+
+        .form-control label {
+            display: block;
+            margin-bottom: 5px;
+            color: #555;
+        }
+
+        .form-control input {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            box-sizing: border-box;
+            /* Ensures padding doesn't add to total width */
+        }
+
+        .error-message {
+            color: red;
+            font-size: 0.9em;
+            margin-top: 5px;
+        }
+
+        button {
+            width: 100%;
+            padding: 10px;
+            background-color: #007bff;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            font-size: 16px;
+            cursor: pointer;
+        }
+
+        button:hover {
+            background-color: #0056b3;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <h2>Register</h2>
+        <form id="registrationForm" novalidate>
+            <div class="form-control">
+                <label for="username">Username</label>
+                <input type="text" id="username" required>
+            </div>
+            <div class="form-control">
+                <label for="email">Email</label>
+                <input type="email" id="email" required>
+            </div>
+            <div class="form-control">
+                <label for="password">Password</label>
+                <input type="password" id="password" required>
+            </div>
+            <div class="form-control">
+                <label for="phone">Phone Number</label>
+                <input type="tel" id="phone">
+            </div>
+            <button type="submit">Submit</button>
+        </form>
+    </div>
+
+    <script type="module">
+        import validateForm from '../dist/validate-form-simple.esm.js'; 
+
+        document.addEventListener('DOMContentLoaded', () => {
+            validateForm('registrationForm'); 
+        });
+    </script>
+</body>
+
+</html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,37 +1,41 @@
+// C:\OSS\FOSS_Issue\move_helper_function\src\index.js
+
+import { showError, clearError, getFieldName } from "./utils/helper.js"; // Đã thêm dòng import này
+
 /**
  * Validates a form identified by the given form ID.
  *
  * @since 2.0.0
  * @param {string} formId - The ID of the form element to validate.
- * 
- *  TODO: Add a second parameter (options) for configuring validation behavior:
- *      - isSubmit: (boolean) whether to auto-submit if valid [default: true]
- *      - withResponse: (function) optional callback to handle validation result
- *      - customRules: (object) additional field-specific validation rules
+ *
+ * TODO: Add a second parameter (options) for configuring validation behavior:
+ * - isSubmit: (boolean) whether to auto-submit if valid [default: true]
+ * - withResponse: (function) optional callback to handle validation result
+ * - customRules: (object) additional field-specific validation rules
  */
 function validateForm(formId) {
   const form = document.getElementById(formId);
   if (!form) return; // Exit if form not found
 
-  form.addEventListener('submit', (event) => {
+  form.addEventListener("submit", (event) => {
     event.preventDefault();
 
     // Clear previous error messages
-    form.querySelectorAll('.error-message').forEach((e) => e.remove());
+    form.querySelectorAll(".error-message").forEach((e) => e.remove());
 
-    const inputs = form.querySelectorAll('input, select, textarea');
+    const inputs = form.querySelectorAll("input, select, textarea");
     let isValid = true;
 
     inputs.forEach((input) => {
       clearError(input);
 
-      if (input.hasAttribute('required') && !input.value.trim()) {
+      if (input.hasAttribute("required") && !input.value.trim()) {
         isValid = false;
-        showError(input, `${getFieldName(input)} must be filled`);
-      } else if (input.type === 'email' && !validateEmail(input.value)) {
+        showError(input, `${getFieldName(input, form)} must be filled`); // Đã cập nhật lời gọi getFieldName
+      } else if (input.type === "email" && !validateEmail(input.value)) {
         isValid = false;
         showError(input, `Invalid email format`);
-      } else if (input.type === 'tel' && !validatePhoneNumber(input.value)) {
+      } else if (input.type === "tel" && !validatePhoneNumber(input.value)) {
         isValid = false;
         showError(input, `Invalid phone number`);
       }
@@ -43,77 +47,30 @@ function validateForm(formId) {
   });
 
   /**
-   * Displays an error message below the input element.
+   * Validate an email address.
    *
-   * @param {HTMLElement} input - The input element.
-   * @param {string} message - The error message to display.
-   * 
-   * TODO: Move to utils/helper.js
+   * @param {string} email
+   * @returns {boolean}
+   *
+   * TODO: Move to separate file for email validation if it'll be.
    */
-  function showError(input, message) {
-    const parent = input.parentElement;
-    const error = parent.querySelector('.error-message');
-    if (error) {
-      error.textContent = message;
-    } else {
-      const errorMessage = document.createElement('div');
-      errorMessage.className = 'error-message';
-      errorMessage.textContent = message;
-      parent.appendChild(errorMessage);
-    }
+  function validateEmail(email) {
+    const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return re.test(String(email).toLowerCase());
   }
 
   /**
-   * Clears the error message for the input element.
-   * 
-   * TODO: Move to utils/helper.js
-   */
-  function clearError(input) {
-    const parent = input.parentElement;
-    const error = parent.querySelector('.error-message');
-    if (error) error.remove();
-  }
-
-  /**
-   * Returns the field name from label if available, else from id.
+   * Validate a phone number.
    *
-   * @param {HTMLElement} input - The input element.
-   * @returns {string} The formatted field name.
-   * 
-   * TODO: Move to utils/helper.js
+   * @param {string} phone
+   * @returns {boolean}
+   *
+   * TODO: Move to separate file for phone validation if it'll be.
    */
-  function getFieldName(input) {
-    const label = form.querySelector(`label[for="${input.id}"]`);
-    if (label) return label.textContent.trim();
-    if (input.id) return input.id.charAt(0).toUpperCase() + input.id.slice(1);
-    return '';
+  function validatePhoneNumber(phone) {
+    const re = /^[0-9\s()+-]{6,20}$/;
+    return re.test(String(phone));
   }
-}
-
-/**
- * Validate an email address.
- *
- * @param {string} email
- * @returns {boolean}
- * 
- * TODO: Move to separate file for email validation if it'll be.
- */
-function validateEmail(email) {
-  const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  return re.test(String(email).toLowerCase());
-}
-
-/**
- * Validate a phone number.
- *
- * @param {string} phone
- * @returns {boolean}
- * 
- * TODO: Move to separate file for phone validation if it'll be.
- */
-function validatePhoneNumber(phone) {
-  const re = /^[0-9\s()+-]{6,20}$/;
-  return re.test(String(phone));
-}
+} // Dấu ngoặc nhọn đóng này là của hàm validateForm()
 
 export default validateForm;

--- a/src/utils/helper.js
+++ b/src/utils/helper.js
@@ -1,1 +1,44 @@
+//C:\OSS\FOSS_Issue\move_helper_function\src\utils\helper.js
 // TODO: add helper function to validate form.
+// src/utils/helper.js
+
+/**
+ * Displays an error message below the input element.
+ *
+ * @param {HTMLElement} input - The input element.
+ * @param {string} message - The error message to display.
+ */
+export function showError(input, message) {
+  const parent = input.parentElement;
+  const error = parent.querySelector(".error-message");
+  if (error) {
+    error.textContent = message;
+  } else {
+    const errorMessage = document.createElement("div");
+    errorMessage.className = "error-message";
+    errorMessage.textContent = message;
+    parent.appendChild(errorMessage);
+  }
+}
+
+/**
+ * Clears the error message for the input element.
+ */
+export function clearError(input) {
+  const parent = input.parentElement;
+  const error = parent.querySelector(".error-message");
+  if (error) error.remove();
+}
+
+/**
+ * Returns the field name from label if available, else from id.
+ *
+ * @param {HTMLElement} input - The input element.
+ * @returns {string} The formatted field name.
+ */
+export function getFieldName(input, form) {
+  const label = form.querySelector(`label[for="${input.id}"]`);
+  if (label) return label.textContent.trim();
+  if (input.id) return input.id.charAt(0).toUpperCase() + input.id.slice(1);
+  return "";
+}


### PR DESCRIPTION
## Fixes Issue

Closes #2

## Changes proposed

* Moved `showError`, `clearError`, and `getFieldName` functions from `src/index.js` to `src/utils/helper.js`.
* Exported these helper functions from `src/utils/helper.js`.
* Imported helper functions back into `src/index.js` and updated the `getFieldName` call to include the `form` parameter.
* Added `novalidate` attribute to the form in `example/index.html` to disable default browser validation and demonstrate custom validation.

## Check List (Check all the applicable boxes) - [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed. - [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
![Screenshot 2025-07-07 022932](https://github.com/user-attachments/assets/4abf2cc8-3284-46f2-a4ba-ef3d6a64f067)

## Note to reviewers